### PR TITLE
Remove matrix inverse error.

### DIFF
--- a/src/GrayModel.cc
+++ b/src/GrayModel.cc
@@ -65,7 +65,6 @@ void GrayModel::compute() {
       v = Ainv * b;
       return;
     }
-    std::cerr << "AprilTags::GrayModel::compute() has underflow in matrix inverse\n";
     //    }
     //    catch (std::underflow_error&) {
     //      std::cerr << "AprilTags::GrayModel::compute() has underflow in matrix inverse\n";


### PR DESCRIPTION
I think this error does not add much value, but just pollutes the command line output when extracting many targets. Can we remove it?